### PR TITLE
Fixed monitor error overrides unexpected command error

### DIFF
--- a/src/Repository/MonitorCommandRepository.php
+++ b/src/Repository/MonitorCommandRepository.php
@@ -131,7 +131,7 @@ class MonitorCommandRepository implements MonitorCommandRepositoryInterface
         $monitorCommand = $this->model
             ->newQuery()
             ->where([
-                'command_id' => $command->id,
+                'command_id' => $command?->id,
                 'host_id' => $host->id,
             ])
             ->orderByDesc('started_at')


### PR DESCRIPTION
For example if executed migration not present in branch we see monitor error

<img width="1867" height="534" alt="mintty_ejTGkaWnsO" src="https://github.com/user-attachments/assets/d3d68737-a2e6-4bb3-a953-e53560cc44cc" />
